### PR TITLE
Use RE instead of isalpha() to check string is alphabetic or not

### DIFF
--- a/SRTpy/srt.py
+++ b/SRTpy/srt.py
@@ -91,9 +91,9 @@ class Srt(object):
     def search(self, dep, arr, date=None, time=None, 
                passengers=None, seat_option='일반', train_type='SRT', include_no_seat=False):
 
-        if dep.isalpha():
+        if re.match(r'^[A-Za-z]+$', dep):
             dep = e2h(dep)
-        if arr.isalpha():
+        if re.match(r'^[A-Za-z]+$', arr):
             arr = e2h(arr)
 
         if date is None:


### PR DESCRIPTION
**This PR fixes bug in ae34df62bd461eb387cd70648eed926ae1c91963.**

`isalpha()` returns true even for Hangul letters. It makes Hangul letters raise a key error in `e2h`.

`isascii()` is introduced in Python 3.7 and we might use it instead of using `isalpha()`. But, I use simple regular expression for those who uses Python version under 3.7.

ps. 구현해주셔서 감사드립니다!